### PR TITLE
Set the slim handler for a skinny zip

### DIFF
--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -1,12 +1,14 @@
 {
     "staging": {
-	"app_function": "zappa_init.app",
-        "aws_region": "eu-central-1",
-        "project_name": "giges",
-        "runtime": "python3.8",
-        "s3_bucket": "zappa-giges-staging",
-        "domain": "integrations-staging.tesselo.com",
-        "certificate_arn": "arn:aws:acm:us-east-1:595064993071:certificate/3cac1dfe-5915-4325-91fa-a53952cbd2e1"
+      "app_function": "zappa_init.app",
+      "aws_region": "eu-central-1",
+      "project_name": "giges",
+      "runtime": "python3.8",
+      "s3_bucket": "zappa-giges-staging",
+      "domain": "integrations-staging.tesselo.com",
+      "certificate_arn": "arn:aws:acm:us-east-1:595064993071:certificate/3cac1dfe-5915-4325-91fa-a53952cbd2e1",
+      "log_level": "INFO",
+      "slim_handler": true
     },
     "production": {
       "log_level": "WARNING",


### PR DESCRIPTION
Zappa or AWS were complaining about the deployment zip file being too large. We are including the test libraries here and that is what is making it big, but we will handle the split of python dependencies in a later PR.