### PR TITLE
Deploy to production, yes!

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -8,9 +8,11 @@ on:
     branches:
       - main
   workflow_dispatch:
-    branches:
-     - main
-    types: deploy-production
+    inputs:
+      sure:
+        description: 'Are you sure to deploy this thing to production?'
+        required: true
+        default: 'Not really'
 
 jobs:
   static_checks:
@@ -104,9 +106,9 @@ jobs:
 
   deploy-production:
     name: Deploy to Production
-    needs: [python_dependencies, static_checks, test, deploy-staging]
+    needs: [python_dependencies, static_checks, test]
     runs-on: ubuntu-latest
-    if: contains('workflow_dispatch', github.event)
+    if: contains('yes', github.event.inputs.sure)
     steps:
       - name: Checkout giges
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR is doing the thing.

I removed the restriction to deploy to be able to deploy to production from any branch, but we need to answer "*yes*". That is, the answer needs to contain yes in order to deploy to production.

This allows something important that we currently don't have in pxapi or tesselo, that is revert a release.

You can see here when I ran it and answered yes: https://github.com/tesselo/giges/actions/runs/1081516610

and here when I answered nope: https://github.com/tesselo/giges/actions/runs/1081528014

:cat2: 