### PR TITLE
Remove alembic from dev dependencies

### DIFF
--- a/dev_requirements.in
+++ b/dev_requirements.in
@@ -1,4 +1,3 @@
-alembic
 black
 boto3
 flake8

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=./dev_requirements.txt dev_requirements.in
 #
-alembic==1.6.5
-    # via -r dev_requirements.in
 appdirs==1.4.4
     # via black
 attrs==21.2.0
@@ -17,9 +15,9 @@ backports.entry-points-selectable==1.1.0
     # via virtualenv
 black==21.7b0
     # via -r dev_requirements.in
-boto3==1.18.14
+boto3==1.18.19
     # via -r dev_requirements.in
-botocore==1.21.14
+botocore==1.21.19
     # via
     #   boto3
     #   s3transfer
@@ -32,9 +30,7 @@ cfgv==3.3.0
 charset-normalizer==2.0.4
     # via requests
 click==8.0.1
-    # via
-    #   black
-    #   flask
+    # via black
 colorama==0.4.4
     # via semgrep
 coverage==5.5
@@ -45,22 +41,12 @@ filelock==3.0.12
     # via virtualenv
 flake8==3.9.2
     # via -r dev_requirements.in
-flask==2.0.1
-    # via flask-sqlalchemy
-flask-sqlalchemy==2.5.1
-    # via pytest-flask-sqlalchemy
-greenlet==1.1.0
-    # via sqlalchemy
-identify==2.2.12
+identify==2.2.13
     # via pre-commit
 idna==3.2
     # via requests
 iniconfig==1.1.1
     # via pytest
-itsdangerous==2.0.1
-    # via flask
-jinja2==3.0.1
-    # via flask
 jmespath==0.10.0
     # via
     #   boto3
@@ -69,12 +55,6 @@ jsonschema==3.2.0
     # via semgrep
 lxml==4.6.3
     # via -r dev_requirements.in
-mako==1.1.4
-    # via alembic
-markupsafe==2.0.1
-    # via
-    #   jinja2
-    #   mako
 mccabe==0.6.1
     # via flake8
 mypy==0.910
@@ -88,7 +68,6 @@ nodeenv==1.6.0
 packaging==21.0
     # via
     #   pytest
-    #   pytest-flask-sqlalchemy
     #   semgrep
 pathspec==0.9.0
     # via black
@@ -98,7 +77,7 @@ platformdirs==2.2.0
     # via virtualenv
 pluggy==0.13.1
     # via pytest
-pre-commit==2.13.0
+pre-commit==2.14.0
     # via -r dev_requirements.in
 py==1.10.0
     # via pytest
@@ -114,18 +93,10 @@ pytest==6.2.4
     # via
     #   -r dev_requirements.in
     #   pytest-cov
-    #   pytest-flask-sqlalchemy
-    #   pytest-mock
 pytest-cov==2.12.1
     # via -r dev_requirements.in
-pytest-mock==3.6.1
-    # via pytest-flask-sqlalchemy
 python-dateutil==2.8.2
-    # via
-    #   alembic
-    #   botocore
-python-editor==1.0.4
-    # via alembic
+    # via botocore
 pyyaml==5.4.1
     # via pre-commit
 regex==2021.8.3
@@ -145,18 +116,13 @@ six==1.16.0
     #   jsonschema
     #   python-dateutil
     #   virtualenv
-sqlalchemy==1.4.22
-    # via
-    #   alembic
-    #   flask-sqlalchemy
-    #   pytest-flask-sqlalchemy
 toml==0.10.2
     # via
     #   mypy
     #   pre-commit
     #   pytest
     #   pytest-cov
-tomli==1.2.0
+tomli==1.2.1
     # via black
 tqdm==4.62.0
     # via semgrep
@@ -166,12 +132,10 @@ urllib3==1.26.6
     # via
     #   botocore
     #   requests
-virtualenv==20.7.0
+virtualenv==20.7.2
     # via pre-commit
 wcmatch==8.2
     # via semgrep
-werkzeug==2.0.1
-    # via flask
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
flask-migrate already adds alembic, and adding alembic here was installing a different version and making the deployment fail