### PR TITLE
Separate dev and deploy python environments

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -33,8 +33,8 @@ jobs:
           black: true
           flake8: true
 
-  python_dependencies:
-    name: Python dependencies
+  python_dev_dependencies:
+    name: Python dev dependencies
     runs-on: ubuntu-latest
     steps:
      - name: Checkout giges
@@ -43,7 +43,7 @@ jobs:
          path: ./giges
      - name: Attempt to use cache
        uses: actions/cache@v2
-       id: cache
+       id: test-cache
        with:
          path: ./giges-venv
          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}
@@ -52,7 +52,7 @@ jobs:
        with:
          python-version: 3.8
      - name: Create virtualenv and install deps
-       if: steps.cache.outputs.cache-hit != 'true'
+       if: steps.test-cache.outputs.cache-hit != 'true'
        run: |
          python -m pip install --upgrade pip virtualenv
          virtualenv -p /usr/bin/python3 ./giges-venv
@@ -61,10 +61,37 @@ jobs:
          pip install -r ./giges/requirements.txt
          pip install -r ./giges/dev_requirements.txt
 
+  python_deploy_dependencies:
+    name: Python deploy dependencies
+    runs-on: ubuntu-latest
+    steps:
+     - name: Checkout giges
+       uses: actions/checkout@v2
+       with:
+         path: ./giges
+     - name: Attempt to use cache
+       uses: actions/cache@v2
+       id: deploy-cache
+       with:
+         path: ./giges-venv
+         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+     - name: Install Python 3
+       uses: actions/setup-python@v1
+       with:
+         python-version: 3.8
+     - name: Create virtualenv and install deps
+       if: steps.deploy-cache.outputs.cache-hit != 'true'
+       run: |
+         python -m pip install --upgrade pip virtualenv
+         virtualenv -p /usr/bin/python3 ./giges-venv
+         source ./giges-venv/bin/activate
+         pip install setuptools==57.5.0
+         pip install -r ./giges/requirements.txt
+
   test:
     name: Tests
     runs-on: ubuntu-latest
-    needs: [python_dependencies]
+    needs: [python_dev_dependencies]
     services:
       postgres:
         image: postgres:latest
@@ -85,9 +112,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./giges
-      - name: Attempt to use cache
+      - name: Use tests cache
         uses: actions/cache@v2
-        id: cache
+        id: test-cache
         with:
           path: ./giges-venv
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}
@@ -101,7 +128,7 @@ jobs:
           GIGES_SETTINGS: giges.settings.TestingSettings
   deploy-staging:
     name: Deploy to Staging
-    needs: [python_dependencies, static_checks, test]
+    needs: [python_deploy_dependencies, static_checks, test]
     runs-on: ubuntu-latest
     if: contains('refs/heads/main', github.ref)
     steps:
@@ -109,12 +136,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./giges
-      - name: Attempt to use cache
+      - name: Use deploy cache
         uses: actions/cache@v2
-        id: cache
+        id: deploy-cache
         with:
           path: ./giges-venv
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
       - name: Deploy
         run: |
           source ./giges-venv/bin/activate
@@ -126,7 +153,7 @@ jobs:
 
   deploy-production:
     name: Deploy to Production
-    needs: [python_dependencies, static_checks, test]
+    needs: [python_deploy_dependencies, static_checks, test]
     runs-on: ubuntu-latest
     if: contains('yes', github.event.inputs.sure) && contains('workflow_dispatch', github.event_name)
     steps:
@@ -134,12 +161,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./giges
-      - name: Attempt to use cache
+      - name: Use deploy cache
         uses: actions/cache@v2
-        id: cache
+        id: deploy-cache
         with:
           path: ./giges-venv
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
       - name: Deploy
         run: |
           source ./giges-venv/bin/activate


### PR DESCRIPTION
In the previous configuration we are deploying the development and test libraries into the staging and production environments. With this change we will no longer do that, and we will have different cache for each python environment.