### PR TITLE
fix(slack): relax validation configuration to allow extra parameters

### DIFF
--- a/giges/app.py
+++ b/giges/app.py
@@ -76,7 +76,7 @@ def create_connexion_app(
     connexion_app.add_api(
         "api.yml",
         validate_responses=True,
-        strict_validation=True,
+        strict_validation=False,
         resolver=RestyResolver("giges.handlers"),
     )
 


### PR DESCRIPTION
Slack is sending us extra things in their payload that was not in the API docs, so I am relaxing the validation. Now it will allow non declared parameters in the body and forms.

Will solve this issue: https://sentry.io/organizations/tesselo/issues/3235993195/